### PR TITLE
Minor Dependency Updates

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.11.2-R0.1-SNAPSHOT</version>
+            <version>1.13.2-R0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/core/src/main/java/app/ashcon/intake/dispatcher/SimpleDispatcher.java
+++ b/core/src/main/java/app/ashcon/intake/dispatcher/SimpleDispatcher.java
@@ -182,7 +182,11 @@ public class SimpleDispatcher implements Dispatcher {
             String passedArguments = Joiner.on(" ").join(Arrays.copyOfRange(split, 1, split.length));
 
             if (mapping != null) {
-                return mapping.getCallable().getSuggestions(passedArguments, locals);
+            	try {
+            		return mapping.getCallable().getSuggestions(passedArguments, locals);
+            	} catch (ArrayIndexOutOfBoundsException ex) {
+            		return Collections.emptyList();
+            	}
             } else {
                 return Collections.emptyList();
             }

--- a/core/src/main/java/app/ashcon/intake/parametric/ArgumentParser.java
+++ b/core/src/main/java/app/ashcon/intake/parametric/ArgumentParser.java
@@ -286,7 +286,7 @@ public final class ArgumentParser {
                 }
             };
 
-            if (TypeToken.of(Optional.class).isAssignableFrom(type)) {
+            if (TypeToken.of(Optional.class).isSupertypeOf(type)) {
                 type = ((ParameterizedType) type).getActualTypeArguments()[0];
 
                 seenOptionalParameter = true;

--- a/core/src/main/java/app/ashcon/intake/parametric/ParametricBuilder.java
+++ b/core/src/main/java/app/ashcon/intake/parametric/ParametricBuilder.java
@@ -50,7 +50,7 @@ public class ParametricBuilder {
     private final List<ExceptionConverter> exceptionConverters = Lists.newArrayList();
     private Authorizer authorizer = new NullAuthorizer();
     private CommandCompleter defaultCompleter = new NullCompleter();
-    private CommandExecutor commandExecutor = new CommandExecutorWrapper(MoreExecutors.sameThreadExecutor());
+    private CommandExecutor commandExecutor = new CommandExecutorWrapper(MoreExecutors.newDirectExecutorService());
 
     public ParametricBuilder(Injector injector) {
         this.injector = injector;


### PR DESCRIPTION
### Minor Dependency Updates
Updated Guava from 17.0 to 27.0.1
Upated Spigot 1.11.2 to 1.13.2

Updated ParametricBuilder.java to handle depreciation
see https://google.github.io/guava/releases/19.0/api/docs/com/google/common/util/concurrent/MoreExecutors.html#sameThreadExecutor()

Updated ArgumentParser.java to handle depreciation
see https://google.github.io/guava/releases/19.0/api/docs/com/google/common/reflect/TypeToken.html#isAssignableFrom(java.lang.reflect.Type)

### SimpleDispatcher ArrayIndexOutOfBounds exception fix 

An exception was thrown when attempting to tab-complete extra arguments.
This just adds a try and catch statement to prevent this.