### PR TITLE
Fix 'wrong number of arguments' invoking Bukkit#getPlayer

### DIFF
--- a/bukkit/src/main/java/app/ashcon/intake/bukkit/util/BukkitUtil.java
+++ b/bukkit/src/main/java/app/ashcon/intake/bukkit/util/BukkitUtil.java
@@ -25,7 +25,7 @@ public class BukkitUtil {
         return (Player)
             Bukkit.class
                 .getDeclaredMethod("getPlayer", String.class, CommandSender.class)
-                .invoke(name, viewer);
+                .invoke(null, name, viewer);
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException error) {
         canSearchByViewer = false;
       }


### PR DESCRIPTION
This was a nasty thing to track down, yet it's only a single line causing the problem.

Under certain circumstances, attempting to run commands with a Player argument will return 'wrong number of arguments' to the player. This exception is actually an IllegalArgumentException coming from reflection.

In `DynamicPlayerProvider`, it uses `BukkitUtil#getPlayer(String, CommandSender)` to try and retrieve the Player object, attempting to use reflection to call the patched viewer-based `Bukkit#getPlayer(String, CommandSender)`.

However, `getPlayer` is a static method, and so the first argument of `invoke` is ignored, [as per the JavaDoc](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Method.html#invoke-java.lang.Object-java.lang.Object...-):
> If the underlying method is static, then the specified obj argument is ignored. It may be null.

This is because the first argument corresponds to the instance the invocation should be applied to - but there isn't one, because it's static.

As a result, because the call is `invoke(name, viewer)`, it's actually only passing one argument, `viewer` to the function, causing the exception.

By setting the first argument to `null` and moving the rest along, we ensure both `name` and `viewer` get passed, the reflection exception no longer occurs, and Player arguments consistently resolve.

I'm assuming that one of the checked exceptions gets thrown and caught at some point, disabling the patch, which is why it doesn't always occur. I can, however, reliably reproduce the issue on a freshly started server by running a command with a Player argument but *not* tabbing the player name before running the command.

Sorry for the very long-winded explanation for a one line change, this took quite some time to diagnose, and I wanted to be thorough in the explanation :D
