### PR TITLE
Hide non-visible players from command suggestions

### DIFF
--- a/bukkit/src/main/java/app/ashcon/intake/bukkit/parametric/provider/DynamicPlayerProvider.java
+++ b/bukkit/src/main/java/app/ashcon/intake/bukkit/parametric/provider/DynamicPlayerProvider.java
@@ -51,6 +51,7 @@ public class DynamicPlayerProvider implements BukkitProvider<Player> {
   public List<String> getSuggestions(
       String prefix, CommandSender sender, Namespace namespace, List<? extends Annotation> mods) {
     return Bukkit.getOnlinePlayers().stream()
+        .filter(bukkit -> sender instanceof Player ? ((Player) sender).canSee(bukkit) : true)
         .map(player -> BukkitUtil.getPlayerName(player, sender))
         .filter(name -> name.toLowerCase().startsWith(prefix.toLowerCase()))
         .sorted()


### PR DESCRIPTION
# Hide non-visible players from command suggestions
Small fix that will hide players who are hidden from having their names being tab-completed by those who can not view them.

Signed-off-by: applenick <applenick@users.noreply.github.com>