### PR TITLE
Implement overridable bindings for intake's default providers

### DIFF
--- a/bukkit/src/main/java/app/ashcon/intake/bukkit/BukkitModule.java
+++ b/bukkit/src/main/java/app/ashcon/intake/bukkit/BukkitModule.java
@@ -16,9 +16,12 @@ public class BukkitModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(CommandSender.class).toProvider(new CommandSenderProvider());
-    bind(Player.class).annotatedWith(Sender.class).toProvider(new ProvidedPlayerProvider());
-    bind(Player.class).toProvider(new DynamicPlayerProvider());
-    bind(World.class).toProvider(new WorldProvider());
+    bind(CommandSender.class).overridable().toProvider(new CommandSenderProvider());
+    bind(Player.class)
+        .annotatedWith(Sender.class)
+        .overridable()
+        .toProvider(new ProvidedPlayerProvider());
+    bind(Player.class).overridable().toProvider(new DynamicPlayerProvider());
+    bind(World.class).overridable().toProvider(new WorldProvider());
   }
 }

--- a/core/src/main/java/app/ashcon/intake/internal/parametric/InternalBinderBuilder.java
+++ b/core/src/main/java/app/ashcon/intake/internal/parametric/InternalBinderBuilder.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 class InternalBinderBuilder<T> implements BindingBuilder<T> {
 
   private final BindingList bindings;
+  private boolean overridable;
   private Key<T> key;
 
   public InternalBinderBuilder(BindingList bindings, Key<T> key) {
@@ -66,8 +67,14 @@ class InternalBinderBuilder<T> implements BindingBuilder<T> {
   }
 
   @Override
+  public BindingBuilder<T> overridable() {
+    this.overridable = true;
+    return this;
+  }
+
+  @Override
   public void toProvider(Provider<T> provider) {
-    bindings.addBinding(key, provider);
+    bindings.addBinding(key, overridable, provider);
   }
 
   @Override

--- a/core/src/main/java/app/ashcon/intake/parametric/Binding.java
+++ b/core/src/main/java/app/ashcon/intake/parametric/Binding.java
@@ -33,6 +33,13 @@ public interface Binding<T> {
   Key<T> getKey();
 
   /**
+   * Whether this binding is overridable.
+   *
+   * @return Whether it is overridable
+   */
+  boolean isOverridable();
+
+  /**
    * Get the provider
    *
    * @return The provider

--- a/core/src/main/java/app/ashcon/intake/parametric/binder/BindingBuilder.java
+++ b/core/src/main/java/app/ashcon/intake/parametric/binder/BindingBuilder.java
@@ -37,6 +37,13 @@ public interface BindingBuilder<T> {
   BindingBuilder<T> annotatedWith(Class<? extends Annotation> annotation);
 
   /**
+   * Whether this binding can be overriden.
+   *
+   * @return The same class
+   */
+  BindingBuilder<T> overridable();
+
+  /**
    * Creates a binding that is provided by the given provider class.
    *
    * @param provider The provider

--- a/core/src/main/java/app/ashcon/intake/parametric/provider/PrimitivesModule.java
+++ b/core/src/main/java/app/ashcon/intake/parametric/provider/PrimitivesModule.java
@@ -27,18 +27,18 @@ public final class PrimitivesModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(Boolean.class).toProvider(BooleanProvider.INSTANCE);
-    bind(boolean.class).toProvider(BooleanProvider.INSTANCE);
-    bind(Integer.class).toProvider(IntegerProvider.INSTANCE);
-    bind(int.class).toProvider(IntegerProvider.INSTANCE);
-    bind(Short.class).toProvider(ShortProvider.INSTANCE);
-    bind(short.class).toProvider(ShortProvider.INSTANCE);
-    bind(Double.class).toProvider(DoubleProvider.INSTANCE);
-    bind(double.class).toProvider(DoubleProvider.INSTANCE);
-    bind(Float.class).toProvider(FloatProvider.INSTANCE);
-    bind(float.class).toProvider(FloatProvider.INSTANCE);
-    bind(String.class).toProvider(StringProvider.INSTANCE);
-    bind(String.class).annotatedWith(Text.class).toProvider(TextProvider.INSTANCE);
-    bind(Duration.class).toProvider(DurationProvider.INSTANCE);
+    bind(Boolean.class).overridable().toProvider(BooleanProvider.INSTANCE);
+    bind(boolean.class).overridable().toProvider(BooleanProvider.INSTANCE);
+    bind(Integer.class).overridable().toProvider(IntegerProvider.INSTANCE);
+    bind(int.class).overridable().toProvider(IntegerProvider.INSTANCE);
+    bind(Short.class).overridable().toProvider(ShortProvider.INSTANCE);
+    bind(short.class).overridable().toProvider(ShortProvider.INSTANCE);
+    bind(Double.class).overridable().toProvider(DoubleProvider.INSTANCE);
+    bind(double.class).overridable().toProvider(DoubleProvider.INSTANCE);
+    bind(Float.class).overridable().toProvider(FloatProvider.INSTANCE);
+    bind(float.class).overridable().toProvider(FloatProvider.INSTANCE);
+    bind(String.class).overridable().toProvider(StringProvider.INSTANCE);
+    bind(String.class).overridable().annotatedWith(Text.class).toProvider(TextProvider.INSTANCE);
+    bind(Duration.class).overridable().toProvider(DurationProvider.INSTANCE);
   }
 }


### PR DESCRIPTION
At the moment, if a binding already exists, then it cannot be overriden. Intake binds its own default providers before configuring other modules (see [BasicBukkitCommandGraph](https://github.com/Electroid/intake/blob/59f112a279b44d1ee28a2f7361a10f75e4d0d6af/bukkit/src/main/java/app/ashcon/intake/bukkit/graph/BasicBukkitCommandGraph.java#L21)). As a result, plugins cannot override intake's default bindings.