### PR TITLE
Fix NoSuchMethodException from getPlayerName

### DIFF
--- a/bukkit/src/main/java/app/ashcon/intake/bukkit/util/BukkitUtil.java
+++ b/bukkit/src/main/java/app/ashcon/intake/bukkit/util/BukkitUtil.java
@@ -24,7 +24,7 @@ public class BukkitUtil {
       try {
         return (Player)
             Bukkit.class
-                .getDeclaredMethod("getPlayer", String.class, CommandSender.class)
+                .getMethod("getPlayer", String.class, CommandSender.class)
                 .invoke(null, name, viewer);
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException error) {
         canSearchByViewer = false;
@@ -37,7 +37,7 @@ public class BukkitUtil {
     if (canSearchByViewer) {
       try {
         return (String)
-            Player.class.getDeclaredMethod("getName", CommandSender.class).invoke(player, viewer);
+            Player.class.getMethod("getName", CommandSender.class).invoke(player, viewer);
       } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException error) {
         canSearchByViewer = false;
       }


### PR DESCRIPTION
In SportPaper, `getPlayerName` is defined in `CommandSender`. As a result, `getDeclaredMethods` fires a `NoSuchMethodException`, since it searches for private methods declared in `Player`.  Therefore `canSearchByViewer` would be false, and so tabbing would show player's real names, rather than their nicknames.

I have kept the method look-up in `Player`, since at one point https://github.com/Electroid/intake/pull/22 worked (perhaps on a Stratus/Walrus fork of SportPaper).